### PR TITLE
Move namespace and set to config

### DIFF
--- a/dbms/src/Dictionaries/AerospikeBlockInputStream.cpp
+++ b/dbms/src/Dictionaries/AerospikeBlockInputStream.cpp
@@ -33,9 +33,19 @@ namespace ErrorCodes
 }
 
 AerospikeBlockInputStream::AerospikeBlockInputStream(
-    const aerospike & client, std::vector<std::unique_ptr<as_key>> && keys, const Block & sample_block, const size_t max_block_size)
-    : client(client), keys(std::move(keys)), max_block_size{max_block_size}
+    const aerospike & client,
+    std::vector<std::unique_ptr<as_key>> && keys,
+    const Block & sample_block,
+    const size_t max_block_size,
+    const std::string & namespace_name,
+    const std::string & set_name)
+    : client(client)
+    , keys(std::move(keys))
+    , max_block_size{max_block_size}
+    , namespace_name{namespace_name}
+    , set_name{set_name}
 {
+    fprintf(stderr, "Found here %s %s", namespace_name.c_str(), set_name.c_str());
     description.init(sample_block);
 }
 
@@ -48,7 +58,7 @@ namespace
     class RecordsHandler
     {
     public:
-        RecordsHandler(MutableColumns * columns, const ExternalResultDescription & description, size_t /*cursor*/)
+        RecordsHandler(MutableColumns * columns, const ExternalResultDescription & description)
             : columns(columns), description(description)
         {
         }
@@ -232,7 +242,7 @@ void InitializeBatchKey(as_key * new_key, const char * namespace_name, const cha
             break;
         default:
             const as_bytes & bytes = base_key->value.bytes;
-            as_key_init_raw(new_key, "ns", "set", bytes.value, bytes.size);
+            as_key_init_raw(new_key, namespace_name, set_name, bytes.value, bytes.size);
             break;
     }
 }
@@ -251,10 +261,10 @@ Block AerospikeBlockInputStream::readImpl()
     as_batch batch;
     as_batch_inita(&batch, current_block_size);
 
-    RecordsHandler recordsHandler(&columns, description, cursor);
+    RecordsHandler recordsHandler(&columns, description);
     for (UInt32 i = 0; i < current_block_size; ++i)
     {
-        InitializeBatchKey(as_batch_keyat(&batch, i), "test", "test_set", keys[cursor + i]);
+        InitializeBatchKey(as_batch_keyat(&batch, i), namespace_name.c_str(), set_name.c_str(), keys[cursor + i]);
     }
 
     const auto batchReadCallback = [](const as_batch_read * results, uint32_t resultSize, void * records_handler_)

--- a/dbms/src/Dictionaries/AerospikeBlockInputStream.h
+++ b/dbms/src/Dictionaries/AerospikeBlockInputStream.h
@@ -16,7 +16,9 @@ namespace DB
             const aerospike& client,
             std::vector<std::unique_ptr<as_key>>&& keys,
             const Block & sample_block,
-            const size_t max_block_size);
+            const size_t max_block_size,
+            const std::string& namespace_name,
+            const std::string& set_name);
 
         ~AerospikeBlockInputStream() override;
 
@@ -31,6 +33,8 @@ namespace DB
         aerospike client;
         std::vector<std::unique_ptr<as_key>> keys;
         const size_t max_block_size;
+        const std::string namespace_name;
+        const std::string set_name;
         ExternalResultDescription description;
         bool all_read = false;
     };

--- a/dbms/src/Dictionaries/AerospikeBlockInputStream.h
+++ b/dbms/src/Dictionaries/AerospikeBlockInputStream.h
@@ -17,8 +17,8 @@ namespace DB
             std::vector<std::unique_ptr<as_key>>&& keys,
             const Block & sample_block,
             const size_t max_block_size,
-            const std::string& namespace_name,
-            const std::string& set_name);
+            const std::string & namespace_name,
+            const std::string & set_name);
 
         ~AerospikeBlockInputStream() override;
 

--- a/dbms/src/Dictionaries/AerospikeDictionarySource.h
+++ b/dbms/src/Dictionaries/AerospikeDictionarySource.h
@@ -18,6 +18,8 @@ public:
         const DictionaryStructure & dict_struct,
         const std::string& host,
         UInt16 port,
+        const std::string & namespace_name,
+        const std::string & set_name,
         as_config * config,
         const Block & sample_block);
     AerospikeDictionarySource(
@@ -57,8 +59,10 @@ public:
     std::string toString() const override;
 private:
     const DictionaryStructure dict_struct;
-    const std::string host; // think how to save const here ??
-    const UInt16 port; // think how to save const here ??
+    const std::string host;
+    const UInt16 port;
+    const std::string namespace_name;
+    const std::string set_name;
     Block sample_block;
     aerospike client; // may be use ptr here
     // may be save global error variable

--- a/dbms/tests/integration/test_external_dictionaries/external_sources.py
+++ b/dbms/tests/integration/test_external_dictionaries/external_sources.py
@@ -440,8 +440,8 @@ class SourceAerospike(ExternalSource):
             <aerospike>
                 <host>{host}</host>
                 <port>{port}</port>
-                <set>{set_name}</set>
                 <namespace>{namespace_name}</namespace>
+                <set>{set_name}</set>
             </aerospike>
         '''.format(
             host=self.docker_hostname,
@@ -458,14 +458,14 @@ class SourceAerospike(ExternalSource):
         self.prepared = True
         print("PREPARED AEROSPIKE")
         print(config)
-    
+
     def compatible_with_layout(self, layout):
         print("compatible AEROSPIKE")
         return layout.is_simple
 
     def _flush_aerospike_db(self):
         keys = []
-        
+
         def handle_record((key, metadata, record)):
             print("Handle record {} {}".format(key, record))
             keys.append(key)
@@ -477,7 +477,6 @@ class SourceAerospike(ExternalSource):
         scan.foreach(handle_record)
 
         [self.client.remove(key) for key in keys]
-
 
     def load_kv_data(self, values):
         self._flush_aerospike_db()
@@ -491,8 +490,6 @@ class SourceAerospike(ExternalSource):
                 assert self.client.exists(key)
         else:
             assert("VALUES SIZE != 2")
-
-        # print(values)
 
     def load_data(self, data, table_name):
         print("Load Data Aerospike")

--- a/dbms/tests/integration/test_external_dictionaries/external_sources.py
+++ b/dbms/tests/integration/test_external_dictionaries/external_sources.py
@@ -428,11 +428,11 @@ class SourceRedis(ExternalSource):
 
 class SourceAerospike(ExternalSource):
     def __init__(self, name, internal_hostname, internal_port,
-                 docker_hostname, docker_port, user, password, storage_type=None):
+                 docker_hostname, docker_port, user, password, namespace_name="test", set_name="test_set", storage_type=None):
         ExternalSource.__init__(self, name, internal_hostname, internal_port,
                  docker_hostname, docker_port, user, password, storage_type)
-        self.namespace = "test"
-        self.set = "test_set"
+        self.namespace_name = namespace_name
+        self.set_name = set_name
 
     def get_source_str(self, table_name):
         print("AEROSPIKE get source str")
@@ -440,11 +440,14 @@ class SourceAerospike(ExternalSource):
             <aerospike>
                 <host>{host}</host>
                 <port>{port}</port>
+                <set>{set_name}</set>
+                <namespace>{namespace_name}</namespace>
             </aerospike>
         '''.format(
             host=self.docker_hostname,
             port=self.docker_port,
-            storage_type=self.storage_type,  # simple or hash_map
+            set_name=self.set_name,
+            namespace_name=self.namespace_name
         )
 
     def prepare(self, structure, table_name, cluster):
@@ -470,7 +473,7 @@ class SourceAerospike(ExternalSource):
         def print_record((key, metadata, record)):
             print("Print record {} {}".format(key, record))
 
-        scan = self.client.scan(self.namespace, self.set)
+        scan = self.client.scan(self.namespace_name, self.set_name)
         scan.foreach(handle_record)
 
         [self.client.remove(key) for key in keys]
@@ -482,7 +485,7 @@ class SourceAerospike(ExternalSource):
         print("Load KV Data Aerospike")
         if len(values[0]) == 2:
             for value in values:
-                key = (self.namespace, self.set, value[0])
+                key = (self.namespace_name, self.set_name, value[0])
                 print(key)
                 self.client.put(key, {"bin_value": value[1]}, policy={"key": aerospike.POLICY_KEY_SEND})
                 assert self.client.exists(key)

--- a/dbms/tests/integration/test_external_dictionaries/test_kv.py
+++ b/dbms/tests/integration/test_external_dictionaries/test_kv.py
@@ -124,7 +124,7 @@ LAYOUTS = [
 SOURCES = [
     # SourceRedis("RedisSimple", "localhost", "6380", "redis1", "6379", "", "", storage_type="simple"),
     # SourceRedis("RedisHash", "localhost", "6380", "redis1", "6379", "", "", storage_type="hash_map"),
-    SourceAerospike("Aerospike", "localhost", "3000", "aerospike1", "3000", "", ""),
+    SourceAerospike("Aerospike", "localhost", "3000", "aerospike1", "3000", "", "", namespace_name="test", set_name="test_set"),
 ]
 
 DICTIONARIES = []


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

For changelog. Remove if this is non-significant change.

Category (leave one):
- Improvement

Short description (up to few sentences):
You can choose arbitrary namespace and set in your aerospike server. Specify these arguments in dictionary config.